### PR TITLE
Use Relinker for native library loading

### DIFF
--- a/tess-two/build.gradle
+++ b/tess-two/build.gradle
@@ -33,7 +33,8 @@ android {
 }
 
 dependencies {
-    implementation "androidx.annotation:annotation:1.1.0"
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.getkeepsafe.relinker:relinker:1.3.1'
 }
 
 

--- a/tess-two/build.gradle
+++ b/tess-two/build.gradle
@@ -27,7 +27,7 @@ android {
 
     externalNativeBuild {
         ndkBuild {
-            path "jni/Android.mk"
+            path 'jni/Android.mk'
         }
     }
 }
@@ -50,7 +50,7 @@ task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     options {
-        links "http://docs.oracle.com/javase/7/docs/api/"
+        links 'http://docs.oracle.com/javase/7/docs/api/'
         linksOffline "http://d.android.com/reference","${android.sdkDirectory}/docs/reference"
     }
 }
@@ -96,8 +96,8 @@ install {
 }
 
 bintray {
-    user = properties.getProperty("bintray.user")
-    key = properties.getProperty("bintray.apikey")
+    user = properties.getProperty('bintray.user')
+    key = properties.getProperty('bintray.apikey')
     configurations = ['archives']
     pkg {
         repo = 'maven'

--- a/tess-two/src/com/googlecode/tesseract/android/PageIterator.java
+++ b/tess-two/src/com/googlecode/tesseract/android/PageIterator.java
@@ -17,13 +17,13 @@
 package com.googlecode.tesseract.android;
 
 import android.graphics.Rect;
-
+import com.getkeepsafe.relinker.ReLinker;
 import com.googlecode.tesseract.android.TessBaseAPI.PageIteratorLevel;
 
 public class PageIterator {
     static {
-        System.loadLibrary("lept");
-        System.loadLibrary("tess");
+        ReLinker.loadLibrary("lept");
+        ReLinker.loadLibrary("tess");
     }
 
     /** Pointer to native page iterator. */


### PR DESCRIPTION
The MR to fix  original issue https://github.com/rmtheis/tess-two/issues/268

CHANGES:
* Add ReLinker as a dependency
* Load native libraries with ReLinker
* Minor cleanup of gradle file - use String instead of GString when is not necessary 